### PR TITLE
fix: migrate 'semver' module to std

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,5 +1,5 @@
-export * as log from "https://deno.land/std@0.121.0/log/mod.ts";
-export * as fs from "https://deno.land/std@0.121.0/fs/mod.ts";
-export * as asserts from "https://deno.land/std@0.121.0/testing/asserts.ts";
-export * as path from "https://deno.land/std@0.121.0/path/mod.ts";
-export * as semver from "https://deno.land/x/semver/mod.ts";
+export * as log from "https://deno.land/std@0.149.0/log/mod.ts";
+export * as fs from "https://deno.land/std@0.149.0/fs/mod.ts";
+export * as asserts from "https://deno.land/std@0.149.0/testing/asserts.ts";
+export * as path from "https://deno.land/std@0.149.0/path/mod.ts";
+export * as semver from "https://deno.land/std@0.149.0/semver/mod.ts";


### PR DESCRIPTION
The 'semver' module has been migrated to the standard library https://deno.land/std/semver